### PR TITLE
Add an include guard to terrarium.h

### DIFF
--- a/terrarium.h
+++ b/terrarium.h
@@ -1,6 +1,8 @@
 // PedalPCB Terrarium Header
 // Copyright (C) 2020 PedalPCB.com
 // http://www.pedalpcb.com
+#ifndef PEDALPCB_TERRARIUM_H_
+#define PEDALPCB_TERRARIUM_H_
 
 namespace terrarium
 {
@@ -34,3 +36,4 @@ namespace terrarium
 			};
 	};
 }
+#endif


### PR DESCRIPTION
I'm including this header in multiple places in my Terrarium-based project, and that results in a redefinition error for the Terrarium class without a guard like this.